### PR TITLE
renaming the original 4

### DIFF
--- a/Renamer/Renamer.cs
+++ b/Renamer/Renamer.cs
@@ -130,15 +130,29 @@ namespace regexKSP {
             else // see if any of the originals are still around
             {
                 if (HighLogic.CurrentGame.CrewRoster["Jebediah Kerman"] != null)
-                {
+                {                    
                     var jeb = HighLogic.CurrentGame.CrewRoster["Jebediah Kerman"];
                     RerollKerbal(jeb);
+                    KerbalRoster.SetExperienceTrait(jeb, KerbalRoster.pilotTrait);
                 }
                 if (HighLogic.CurrentGame.CrewRoster["Bill Kerman"] != null)
                 {
                     var bill = HighLogic.CurrentGame.CrewRoster["Bill Kerman"];
                     RerollKerbal(bill);
-                }                
+                    KerbalRoster.SetExperienceTrait(bill, KerbalRoster.engineerTrait);
+                }
+                if (HighLogic.CurrentGame.CrewRoster["Bob Kerman"] != null)
+                {
+                    var bob = HighLogic.CurrentGame.CrewRoster["Bob Kerman"];
+                    RerollKerbal(bob);
+                    KerbalRoster.SetExperienceTrait(bob, KerbalRoster.scientistTrait);
+                }
+                if (HighLogic.CurrentGame.CrewRoster["Valentina Kerman"] != null)
+                {
+                    var val = HighLogic.CurrentGame.CrewRoster["Valentina Kerman"];
+                    RerollKerbal(val);
+                    KerbalRoster.SetExperienceTrait(val, KerbalRoster.pilotTrait);
+                }
             }
 
             RerollKerbal(kerbal);

--- a/Renamer/Renamer.cs
+++ b/Renamer/Renamer.cs
@@ -118,43 +118,76 @@ namespace regexKSP {
 	        GameEvents.onKerbalAdded.Add(new EventData<ProtoCrewMember>.OnEvent(OnKerbalAdded));
 		}
 
-	    public void OnKerbalAdded(ProtoCrewMember kerbal) {
-			if(preserveOriginals) {
-				if(kerbal.name == "Jebediah Kerman" || kerbal.name == "Bill Kerman" || kerbal.name == "Bob Kerman" || kerbal.name == "Valentina Kerman") {
-					return;
-				}
-			}
-			UnityEngine.Random.InitState(System.DateTime.Now.Millisecond * kerbal.name.GetHashCode());
+	    public void OnKerbalAdded(ProtoCrewMember kerbal)
+        {
+            if (preserveOriginals)
+            {
+                if (kerbal.name == "Jebediah Kerman" || kerbal.name == "Bill Kerman" || kerbal.name == "Bob Kerman" || kerbal.name == "Valentina Kerman")
+                {
+                    return;
+                }
+            }
+            else // see if any of the originals are still around
+            {
+                if (HighLogic.CurrentGame.CrewRoster["Jebediah Kerman"] != null)
+                {
+                    var jeb = HighLogic.CurrentGame.CrewRoster["Jebediah Kerman"];
+                    RerollKerbal(jeb);
+                }
+                if (HighLogic.CurrentGame.CrewRoster["Bill Kerman"] != null)
+                {
+                    var bill = HighLogic.CurrentGame.CrewRoster["Bill Kerman"];
+                    RerollKerbal(bill);
+                }                
+            }
 
-			if(generateNewStats) {
-				if(kerbal.type == ProtoCrewMember.KerbalType.Crew || kerbal.type == ProtoCrewMember.KerbalType.Applicant) {
-					// generate some new stats
-					kerbal.stupidity = rollStupidity();
-					kerbal.courage = rollCourage();
-					kerbal.isBadass = (UnityEngine.Random.Range(0.0f, 1.0f) < badassPercent);
-	
-					float rand = UnityEngine.Random.Range(0.0f, 1.0f);
-					if(rand < 0.33f) {
-						KerbalRoster.SetExperienceTrait(kerbal, "Pilot");
-					} else if(rand < 0.66f) {
-						KerbalRoster.SetExperienceTrait(kerbal, "Engineer");
-					} else {
-						KerbalRoster.SetExperienceTrait(kerbal, "Scientist");
-					}
-	
-					if(UnityEngine.Random.Range(0.0f, 1.0f) < femalePercent) {
-						kerbal.gender = ProtoCrewMember.Gender.Female;
-					} else {
-						kerbal.gender = ProtoCrewMember.Gender.Male;
-					}
-				}
-			}
+            RerollKerbal(kerbal);
+        }
 
-			string name = this.getName(kerbal);
-			if(name.Length > 0) {
-	        	kerbal.ChangeName(name);
-			}
-	    }
+        private void RerollKerbal(ProtoCrewMember kerbal)
+        {
+            UnityEngine.Random.InitState(System.DateTime.Now.Millisecond * kerbal.name.GetHashCode());
+
+            if (generateNewStats)
+            {
+                if (kerbal.type == ProtoCrewMember.KerbalType.Crew || kerbal.type == ProtoCrewMember.KerbalType.Applicant)
+                {
+                    // generate some new stats
+                    kerbal.stupidity = rollStupidity();
+                    kerbal.courage = rollCourage();
+                    kerbal.isBadass = (UnityEngine.Random.Range(0.0f, 1.0f) < badassPercent);
+
+                    float rand = UnityEngine.Random.Range(0.0f, 1.0f);
+                    if (rand < 0.33f)
+                    {
+                        KerbalRoster.SetExperienceTrait(kerbal, "Pilot");
+                    }
+                    else if (rand < 0.66f)
+                    {
+                        KerbalRoster.SetExperienceTrait(kerbal, "Engineer");
+                    }
+                    else
+                    {
+                        KerbalRoster.SetExperienceTrait(kerbal, "Scientist");
+                    }
+
+                    if (UnityEngine.Random.Range(0.0f, 1.0f) < femalePercent)
+                    {
+                        kerbal.gender = ProtoCrewMember.Gender.Female;
+                    }
+                    else
+                    {
+                        kerbal.gender = ProtoCrewMember.Gender.Male;
+                    }
+                }
+            }
+
+            string name = this.getName(kerbal);
+            if (name.Length > 0)
+            {
+                kerbal.ChangeName(name);
+            }
+        }
 
 	    private string getName(ProtoCrewMember c) {
 	        string firstName = "";


### PR DESCRIPTION
I've got a (somewhat unelegant) update that restores the ability to rename the original 4.  It looks like OnKerbalAdded doesn't trigger for the original 4 so I've added a check to see if they are still around when OnKerbalAdded does get called and reroll their stats.  I've only implemented this for Jeb and Bill to prove it works. 

This is my first ever pull request so please tell me if I'm doing this wrong.