### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/KerbalRenamer/KerbalRenamer.version
+++ b/GameData/KerbalRenamer/KerbalRenamer.version
@@ -1,6 +1,6 @@
 {
   "NAME": "Kerbal Renamer",
-  "URL": "https://github.com/KSP-RO/KerbalRenamer",
+  "URL": "https://github.com/KSP-RO/KerbalRenamer/raw/master/GameData/KerbalRenamer/KerbalRenamer.version",
   "DOWNLOAD": "https://github.com/KSP-RO/KerbalRenamer/releases",
   "GITHUB": {
     "USERNAME": "KSP-RO",


### PR DESCRIPTION
The "URL" property is supposed to point to an online copy of the version file, so KSP-AVC can check for updates.
Now it does.